### PR TITLE
Skip empty declarations

### DIFF
--- a/lib/map-functions.js
+++ b/lib/map-functions.js
@@ -12,6 +12,11 @@ module.exports = function (cssValue, map) {
   if (cssValue.indexOf('progid:DXImageTransform') !== -1) {
     return cssValue;
   }
+  
+  // Skip empty declarations
+  if (cssValue === "") {
+    return cssValue;
+  }
 
   // Parse the syntax tree,
   // considering that input is a CSS value

--- a/lib/map-functions.js
+++ b/lib/map-functions.js
@@ -14,7 +14,7 @@ module.exports = function (cssValue, map) {
   }
   
   // Skip empty declarations
-  if (cssValue === "") {
+  if (cssValue === '') {
     return cssValue;
   }
 

--- a/test/fixtures/resolve-spelling.css
+++ b/test/fixtures/resolve-spelling.css
@@ -16,4 +16,5 @@ body {
   background: resolve('kateryna.jpg#baz');
   background: resolve('Gupsy Fortuneteller.jpg');
   filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#ffffff', endColorstr='#eeeeee', GradientType=0);
+  font-size ;
 }

--- a/test/fixtures/resolve-spelling.expected.css
+++ b/test/fixtures/resolve-spelling.expected.css
@@ -16,4 +16,5 @@ body {
   background: url('/alpha/kateryna.jpg#baz');
   background: url('/alpha/Gupsy%20Fortuneteller.jpg');
   filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#ffffff', endColorstr='#eeeeee', GradientType=0);
+  font-size: ;
 }


### PR DESCRIPTION
Prevents postcss-assets throwing an error if it encounters an empty declaration.