### PR TITLE
Changes order of paths then path with `basePath` gets higher priority

### DIFF
--- a/index.js
+++ b/index.js
@@ -95,7 +95,7 @@ Assets.prototype.matchPath = function (assetPath) {
   // If inputPath was provided then prepend it to the list of load paths,
   // otherwise leave them as they were
   if (typeof this.inputPath === 'string') {
-    loadPaths = [path.dirname(this.inputPath)].concat(this.options.loadPaths);
+    loadPaths = this.options.loadPaths.concat([path.dirname(this.inputPath)]);
   } else {
     loadPaths = this.options.loadPaths;
   }

--- a/test/fixtures/resolve-from-source.expected.css
+++ b/test/fixtures/resolve-from-source.expected.css
@@ -1,3 +1,3 @@
 body {
-  background: url('/fixtures/kobzar.jpg');
+  background: url('/fixtures/alpha/kobzar.jpg');
 }


### PR DESCRIPTION
If some asset exists at current path and at path with `basePath` then `matchingPath` will catch wrong entire. This PR changes order of paths and makes path with `basePath` higher priority.